### PR TITLE
docs: add local lint/type-check instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,3 +478,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
   - Optional call tracking with performance-optimised defaults
 - Comprehensive test suite with 26 tests
 - Zero runtime dependencies
+For development: run linting and type checks locally using uv as follows: `uv run ruff check .`, `uv run ruff format --check .`, and `uv run mypy src/`.


### PR DESCRIPTION
# docs: add local lint/type-check instructions

This PR adds a single line to the README.md documentation explaining how developers can run linting and type checking locally using uv. The addition provides clear instructions for running:
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src/

This change was made as a minimal test to verify repository access, linting, and PR creation workflow.

Link to Devin run:
https://app.devin.ai/sessions/683ffa0096ad433297c566bd57792441

Requester:
Louis Mandelstam — @man8

Notes:
- No functional code changes; documentation-only update.
